### PR TITLE
Update Svelte to ^3.31.0 and add types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2236,14 +2236,13 @@
       }
     },
     "rollup-plugin-svelte": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.0.1.tgz",
-      "integrity": "sha512-kS9/JZMBNgpKTqVKlwV8mhmGwxu8NiNf6+n5ZzdZ8yDp3+ADqjf8Au+JNEpoOn6kLlh1hLS2Gsa76k9RP57HDQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-7.1.0.tgz",
+      "integrity": "sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==",
       "dev": true,
       "requires": {
         "require-relative": "^0.8.7",
-        "rollup-pluginutils": "^2.8.2",
-        "sourcemap-codec": "^1.4.8"
+        "rollup-pluginutils": "^2.8.2"
       }
     },
     "rollup-pluginutils": {
@@ -2435,9 +2434,9 @@
       }
     },
     "svelte": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.26.0.tgz",
-      "integrity": "sha512-9tclNfffORwbSewfofEHddqXhfhFvFcgJlkF3QhZfMuoh6whPOPY87eHiJRHph4na3VxQoGDyEWAZcNAl1K/2A==",
+      "version": "3.43.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.43.1.tgz",
+      "integrity": "sha512-nvPIaKx4HLzYlSdquISZpgG1Kqr2VAWQjZOt3Iwm3UhbqmA0LnSx4k1YpRMEhjQYW3ZCqQoK8Egto9tv4YewMA==",
       "dev": true
     },
     "svgo": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"svelte": "src/index.js",
 	"module": "dist/index.mjs",
 	"main": "dist/index.js",
+	"types": "types/index.d.ts",
 	"license": "MIT",
 	"scripts": {
 		"build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@budibase/svelte-ag-grid",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"svelte": "src/index.js",
 	"module": "dist/index.mjs",
 	"main": "dist/index.js",
@@ -18,8 +18,8 @@
 		"@rollup/plugin-node-resolve": "^9.0.0",
 		"rollup": "^2.0.0",
 		"rollup-plugin-postcss": "^3.1.8",
-		"rollup-plugin-svelte": "^6.0.0",
-		"svelte": "^3.0.0"
+		"rollup-plugin-svelte": "^7.1.0",
+		"svelte": "^3.31.0"
 	},
 	"keywords": [
 		"svelte"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	],
 	"files": [
 		"src",
+    "types",
 		"dist"
 	]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,21 +1,16 @@
-import { SvelteComponent } from "svelte";
+import { SvelteComponentTyped } from "svelte";
+import { ColDef, GridOptions } from "ag-grid-community"
 
-/* TODO: Use when updated to Svelte ^3.31.0 with SvelteComponentTyped */
-/**
- * import { ColDef, GridOptions } from "ag-grid-community"
- *
- * interface AgGridProps {
- *  columnDefs: ColDef;
- *  data: any;
- *  theme?: string;
- *  options?: GridOptions;
- *  loading?: boolean;
- * }
- *
- * declare class AgGridComponent extends SvelteComponentTyped<AgGridProps> {}
-*/
+interface AgGridProps {
+  columnDefs: ColDef;
+  data: any;
+  theme?: string;
+  options?: GridOptions;
+  loading?: boolean;
+}
 
-declare class AgGridComponent extends SvelteComponent { }
+declare class AgGridComponent extends SvelteComponentTyped<AgGridProps> { }
+
 
 export default AgGridComponent;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,12 @@
+import {SvelteComponentTyped} from "svelte";
+// import {} from "ag-grid-community"
+
+interface AgGridProps {
+    columnDefs: any;
+    data: any;
+    theme?: string;
+    options?: any;
+    loading?: boolean;
+}
+
+export class AgGrid extends SvelteComponentTyped<AgGridProps>{};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,21 @@
-import {SvelteComponentTyped} from "svelte";
-// import {} from "ag-grid-community"
+import { SvelteComponent } from "svelte";
 
-interface AgGridProps {
-    columnDefs: any;
-    data: any;
-    theme?: string;
-    options?: any;
-    loading?: boolean;
-}
+/* TODO: Use when updated to Svelte ^3.31.0 with SvelteComponentTyped */
+/**
+ * import { ColDef, GridOptions } from "ag-grid-community"
+ *
+ * interface AgGridProps {
+ *  columnDefs: ColDef;
+ *  data: any;
+ *  theme?: string;
+ *  options?: GridOptions;
+ *  loading?: boolean;
+ * }
+ *
+ * declare class AgGridComponent extends SvelteComponentTyped<AgGridProps> {}
+*/
 
-export class AgGrid extends SvelteComponentTyped<AgGridProps>{};
+declare class AgGridComponent extends SvelteComponent { }
+
+export default AgGridComponent;
+

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@ import { SvelteComponentTyped } from "svelte";
 import { ColDef, GridOptions } from "ag-grid-community"
 
 interface AgGridProps {
-  columnDefs: ColDef;
+  columnDefs: ColDef[];
   data: any;
   theme?: string;
   options?: GridOptions;


### PR DESCRIPTION
## Updated:
- Use Svelte `^3.31.0` to have access to `SvelteComponentTyped`
- Use rollup-plugin-svelte `7.1.0` for compatibility with svelte `v3.31.0`
- Typed exports from index.js

## Version
Increased to `v1.1.0` due to possible conflicts with Svelte `v3.31.0`